### PR TITLE
Fix SVC_Print

### DIFF
--- a/r5dev/include/hooks.h
+++ b/r5dev/include/hooks.h
@@ -108,6 +108,13 @@ namespace Hooks
 	extern MSG_EngineErrorFn originalMSG_EngineError;
 #pragma endregion
 
+#pragma region CNetMessage
+	bool SVC_Print_Process(__int64 thisptr);
+
+	using SVC_Print_ProcessFn = bool(*)(__int64);
+	extern SVC_Print_ProcessFn originalSVC_Print_Process;
+#pragma endregion
+
 	void InstallHooks();
 	void RemoveHooks();
 	void ToggleNetTrace();

--- a/r5dev/include/patterns.h
+++ b/r5dev/include/patterns.h
@@ -78,6 +78,11 @@ namespace
 	// Un-used atm.
 	// DWORD64 p_KeyValues_FindKey = /*1404744E0*/ reinterpret_cast<DWORD64>(PatternScan("r5apex.exe", "40 56 57 41 57 48 81 EC ?? ?? ?? ?? 45"));
 
+#pragma region CNetMessage
+	/*0x1402D0810*/
+	FUNC_AT_ADDRESS(addr_SVC_Print_Process, bool(*)(__int64*), r5_patterns.PatternSearch("48 8B D1 48 8B 49 18 48 8B 01 48 FF 60 28").GetPtr());
+#pragma endregion
+
 	void PrintHAddress() // Test the sigscan results
 	{
 		std::cout << "+--------------------------------------------------------+" << std::endl;
@@ -99,6 +104,7 @@ namespace
 		PRINT_ADDRESS("CBaseFileSystem::FileSystemWarning", addr_CBaseFileSystem_FileSystemWarning);
 		PRINT_ADDRESS("MSG_EngineError", addr_MSG_EngineError);
 		PRINT_ADDRESS("MemAlloc_Wrapper", addr_MemAlloc_Wrapper);
+		PRINT_ADDRESS("SVC_Print::Process", addr_SVC_Print_Process);
 		std::cout << "+--------------------------------------------------------+" << std::endl;
 		// TODO implement error handling when sigscan fails or result is 0
 	}

--- a/r5dev/r5dev.vcxproj
+++ b/r5dev/r5dev.vcxproj
@@ -379,6 +379,7 @@ if not EXIST $(SolutionDir)r5net\lib\$(Configuration)\r5net.lib (
     </ClCompile>
     <ClCompile Include="src\hooks\cbasefilesystem.cpp" />
     <ClCompile Include="src\hooks\chlclient.cpp" />
+    <ClCompile Include="src\hooks\cnetmessage.cpp" />
     <ClCompile Include="src\hooks\cvengineserver.cpp" />
     <ClCompile Include="src\hooks\hooks.cpp" />
     <ClCompile Include="src\hooks\iconvar.cpp" />

--- a/r5dev/r5dev.vcxproj.filters
+++ b/r5dev/r5dev.vcxproj.filters
@@ -103,6 +103,9 @@
     <Filter Include="hooks\src\cbasefilesystem">
       <UniqueIdentifier>{90ee1072-2d57-4d4e-aa1e-f19a81e6b27f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="hooks\src\cnetmessage">
+      <UniqueIdentifier>{3f44c89c-ddae-4d7e-b003-5a18be89d82e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\dllmain.cpp">
@@ -191,6 +194,9 @@
     </ClCompile>
     <ClCompile Include="src\hooks\netchannel.cpp">
       <Filter>hooks\src\netchannel</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hooks\cnetmessage.cpp">
+      <Filter>hooks\src\cnetmessage</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/r5dev/src/hooks/cnetmessage.cpp
+++ b/r5dev/src/hooks/cnetmessage.cpp
@@ -1,0 +1,51 @@
+#include "pch.h"
+#include "hooks.h"
+
+namespace Hooks
+{
+	SVC_Print_ProcessFn originalSVC_Print_Process = nullptr;
+}
+
+static std::ostringstream oss_print;
+static auto ostream_sink_print = std::make_shared<spdlog::sinks::ostream_sink_st>(oss_print);
+
+//-----------------------------------------------------------------------------
+// Purpose: log the console messages sent by server
+//-----------------------------------------------------------------------------
+bool Hooks::SVC_Print_Process(__int64 thisptr)
+{
+	// TODO: replace with VT hook
+	// This is also a call to the handler and for CLC_ClientInfo::Process
+	// CNetMessage::GetTypeID ?? | VTF 12
+	if (((__int64 (*)(__int64))(*(void***)thisptr)[12])(thisptr) != 2096)
+	{
+		return originalSVC_Print_Process(thisptr);
+	}
+
+	static bool initialized = false;
+
+	static auto iconsole = spdlog::stdout_logger_mt("svc_print_iconsole"); // in-game console
+	static auto wconsole = spdlog::stdout_logger_mt("svc_print_wconsole"); // windows console
+
+	oss_print.str("");
+	oss_print.clear();
+
+	if (!initialized)
+	{
+		iconsole = std::make_shared<spdlog::logger>("ostream", ostream_sink_print);
+		iconsole->set_pattern("[%S.%e] %v");
+		iconsole->set_level(spdlog::level::info);
+		wconsole->set_pattern("[%S.%e] %v");
+		wconsole->set_level(spdlog::level::info);
+		initialized = true;
+	}
+
+	const char* m_szText = *reinterpret_cast<const char**>(thisptr + 0x28);
+
+	iconsole->info(m_szText);
+	wconsole->info(m_szText);
+
+	Items.push_back(Strdup(oss_print.str().c_str()));
+
+	return true;
+}

--- a/r5dev/src/hooks/hooks.cpp
+++ b/r5dev/src/hooks/hooks.cpp
@@ -48,6 +48,10 @@ void Hooks::InstallHooks()
 	MH_CreateHook(addr_MSG_EngineError, &Hooks::MSG_EngineError, reinterpret_cast<void**>(&originalMSG_EngineError));
 
 	///////////////////////////////////////////////////////////////////////////////
+	// Hook CNetMessage functions
+	MH_CreateHook(addr_SVC_Print_Process, &Hooks::SVC_Print_Process, reinterpret_cast<void**>(&originalSVC_Print_Process));
+
+	///////////////////////////////////////////////////////////////////////////////
 	// Hook WinAPI
 	if (Module user32dll = Module("user32.dll"); user32dll.GetModuleBase()) // Is user32.dll valid?
 	{
@@ -98,6 +102,10 @@ void Hooks::InstallHooks()
 	///////////////////////////////////////////////////////////////////////////////
     // Enabled Utility hooks
 	MH_EnableHook(addr_MSG_EngineError);
+
+	///////////////////////////////////////////////////////////////////////////////
+	// Enabled CNetMessage hooks
+	MH_EnableHook(addr_SVC_Print_Process);
 }
 
 void Hooks::RemoveHooks()
@@ -147,6 +155,10 @@ void Hooks::RemoveHooks()
 	///////////////////////////////////////////////////////////////////////////////
 	// Unhook CBaseFileSystem functions.
 	//MH_RemoveHook(addr_CBaseFileSystem_FileSystemWarning);
+
+	///////////////////////////////////////////////////////////////////////////////
+	// Unhook CNetMessage functions
+	MH_RemoveHook(addr_SVC_Print_Process);
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Reset Minhook


### PR DESCRIPTION
Console messages sent by server are now displayed in console, mainly for operability of the `status` and `ping` commands